### PR TITLE
Expand testsuite class

### DIFF
--- a/nrtest/__init__.py
+++ b/nrtest/__init__.py
@@ -52,7 +52,6 @@ class Application(Metadata):
         version
         exe: executable [path]
         setup_script: environment setup script [path]
-        tests_path [path]
 
     Optional fields:
         description
@@ -62,7 +61,6 @@ class Application(Metadata):
         'name',
         'version',
         'exe',
-        'tests_path',
     ]
     _testing_allows = {
         'description': None,

--- a/nrtest/__init__.py
+++ b/nrtest/__init__.py
@@ -1,4 +1,4 @@
-from nrtest.__version__ import __version__
+from .__version__ import __version__
 
 
 class Metadata(dict):
@@ -53,7 +53,6 @@ class Application(Metadata):
         exe: executable [path]
         setup_script: environment setup script [path]
         tests_path [path]
-        benchmark_path [path]
 
     Optional fields:
         description
@@ -64,7 +63,6 @@ class Application(Metadata):
         'version',
         'exe',
         'tests_path',
-        'benchmark_path',
     ]
     _testing_allows = {
         'description': None,

--- a/nrtest/compare.py
+++ b/nrtest/compare.py
@@ -12,22 +12,17 @@ class CompareException(Exception):
 
 
 def compare_testsuite(ts_sut, ts_ref, tolerance):
-    """Compare testsuite results against a benchmark.
+    """Compare the results of a testsuite against a benchmark.
 
     Args:
         ts_sut: SUT testsuite
-        ts_ref: benchamrk testsuite
+        ts_ref: benchmark testsuite
         tolerance: relative precision at which results considered compatible
 
-    Returns:
-        Boolean: whether results are compatible
+    Returns: boolean compatibility
     """
     # check each testsuite is individually valid before beginning
-    try:
-        ts_sut.validate_for_compare()
-        ts_ref.validate_for_compare()
-    except Exception as e:
-        logging.error(str(e))
+    if not ts_sut.valid_for_compare() or not ts_ref.valid_for_compare():
         return False
 
     # check testsuites are comparable
@@ -43,8 +38,8 @@ def compare_testsuite(ts_sut, ts_ref, tolerance):
         test_sut = tests_sut[name]
         test_ref = tests_ref[name]
 
-        test_sut.dir = join(ts_sut.dir, test_sut.dir)
-        test_ref.dir = join(ts_ref.dir, test_ref.dir)
+        test_sut.dir = join(ts_sut.benchmark_path, test_sut.dir)
+        test_ref.dir = join(ts_ref.benchmark_path, test_ref.dir)
 
         if not compare_test(test_sut, test_ref, tolerance):
             compatible = False
@@ -53,15 +48,14 @@ def compare_testsuite(ts_sut, ts_ref, tolerance):
 
 
 def compare_test(test_sut, test_ref, tolerance):
-    """Compare test results against a benchmark.
+    """Compare the results of a single test against a benchmark.
 
     Args:
         test_sut: SUT test
         test_ref: benchmark test
         tolerance: relative precision at which results considered compatible
 
-    Returns:
-        Boolean: whether results are compatible
+    Returns: boolean compatibility
     """
     logger = logging.getLogger(test_sut.name)
 

--- a/nrtest/compare.py
+++ b/nrtest/compare.py
@@ -38,8 +38,8 @@ def compare_testsuite(ts_sut, ts_ref, tolerance):
         test_sut = tests_sut[name]
         test_ref = tests_ref[name]
 
-        test_sut.dir = join(ts_sut.benchmark_path, test_sut.dir)
-        test_ref.dir = join(ts_ref.benchmark_path, test_ref.dir)
+        test_sut.subdir = join(ts_sut.benchmark_path, test_sut.subdir)
+        test_ref.subdir = join(ts_ref.benchmark_path, test_ref.subdir)
 
         if not compare_test(test_sut, test_ref, tolerance):
             compatible = False
@@ -73,8 +73,8 @@ def compare_test(test_sut, test_ref, tolerance):
         # return False immediately if any are incompatible
         max_diff = 0.0
         for fname, ftype in test_sut.output_files.iteritems():
-            path_sut = join(test_sut.dir, fname)
-            path_ref = join(test_ref.dir, fname)
+            path_sut = join(test_sut.subdir, fname)
+            path_ref = join(test_ref.subdir, fname)
 
             try:
                 diff = factory(ftype)(path_sut, path_ref)

--- a/nrtest/execute.py
+++ b/nrtest/execute.py
@@ -3,6 +3,10 @@ import logging
 
 
 def execute_testsuite(ts):
+    """Execute the testsuite.
+
+    Returns: boolean success
+    """
     if not ts.valid_for_execute():
         return False
 

--- a/nrtest/execute.py
+++ b/nrtest/execute.py
@@ -1,0 +1,18 @@
+# system imports
+import logging
+
+
+def execute_testsuite(ts):
+    if not ts.valid_for_execute():
+        return False
+
+    success = True
+    for test in sorted(ts.tests):
+        if not execute_test(test, ts.app, ts.benchmark_path):
+            success = False
+
+    return success
+
+
+def execute_test(test, app, benchmark_path):
+    return test.execute(app, benchmark_path)

--- a/nrtest/test.py
+++ b/nrtest/test.py
@@ -1,14 +1,13 @@
 from os import makedirs, environ
 from os.path import exists, isfile, isdir, join, split
 import tempfile
-import re
 import shutil
 import logging
 import csv
 
 from . import Metadata
 from .process import source, execute, monitor
-from .utility import color
+from .utility import color, slugify
 
 PASS = color('passed', 'g')
 FAIL = color('failed', 'r')
@@ -65,7 +64,7 @@ class Test(Metadata):
 
     def __init__(self, *args, **kwargs):
         super(Test, self).__init__(*args, **kwargs)
-        self.subdir = _slugify(self.name)
+        self.subdir = slugify(self.name)
         self.out_log = 'stdout.log'
         self.err_log = 'stderr.log'
         self.perf_log = 'performance.log'
@@ -207,9 +206,3 @@ def _copy_filepath(rel_path, src_dir, dest):
     if not isdir(dest):
         makedirs(dest)
     shutil.copy(join(src_dir, rel_path), dest)
-
-
-def _slugify(s):
-    slug = s.strip().replace(' ', '_')
-    slug = re.sub(r'(?u)[^-\w.]', '', slug)
-    return slug

--- a/nrtest/test.py
+++ b/nrtest/test.py
@@ -1,6 +1,5 @@
 from os import makedirs, environ
 from os.path import exists, isfile, isdir, join, split
-from six.moves import range
 import tempfile
 import re
 import shutil
@@ -49,7 +48,6 @@ class Test(Metadata):
         'input_files': [],
         'output_files': {},
         'fail_strings': [],
-        'timeout': None,
     }
     _compare_requires = [
         'name',
@@ -80,9 +78,9 @@ class Test(Metadata):
             self.logger.addHandler(handler)
             self.logger.propagate = False
 
-    def execute(self, app):
+    def execute(self, app, benchmark_path):
         input_dir = app.tests_path
-        output_dir = join(app.benchmark_path, self.dir)
+        output_dir = join(benchmark_path, self.dir)
 
         try:
             self.logger.debug('Starting execution')

--- a/nrtest/test.py
+++ b/nrtest/test.py
@@ -53,7 +53,7 @@ class Test(Metadata):
         'name',
         'version',
         'description',
-        'dir',
+        'subdir',
         'out_log',
         'err_log',
         'perf_log',
@@ -65,7 +65,7 @@ class Test(Metadata):
 
     def __init__(self, *args, **kwargs):
         super(Test, self).__init__(*args, **kwargs)
-        self.dir = _slugify(self.name)
+        self.subdir = _slugify(self.name)
         self.out_log = 'stdout.log'
         self.err_log = 'stderr.log'
         self.perf_log = 'performance.log'
@@ -79,8 +79,8 @@ class Test(Metadata):
             self.logger.propagate = False
 
     def execute(self, app, benchmark_path):
-        input_dir = app.tests_path
-        output_dir = join(benchmark_path, self.dir)
+        input_dir = self.input_dir
+        output_dir = join(benchmark_path, self.subdir)
 
         try:
             self.logger.debug('Starting execution')
@@ -98,6 +98,21 @@ class Test(Metadata):
             self.logger.info(PASS)
 
         return self.passed
+
+    def valid_for_execute(self):
+        if not hasattr(self, 'input_dir'):
+            logging.error('Test input directory not specified')
+            return False
+
+        p = self.input_dir
+        if not isdir(p):
+            logging.error('Tests directory not found: "%s"' % p)
+            return False
+
+        return True
+
+    def valid_for_compare(self):
+        return True
 
     def _precheck_execute(self, input_dir, output_dir):
         for fname in self.input_files:

--- a/nrtest/testsuite.py
+++ b/nrtest/testsuite.py
@@ -40,7 +40,9 @@ class TestSuite(object):
         tests = []
         for p in test_config_paths:
             with open(p) as f:
-                tests.append(Test.for_execution(json.load(f)))
+                test = Test.for_execution(json.load(f))
+                test.input_dir = os.path.dirname(p)
+                tests.append(test)
 
         return cls(app, tests, benchmark_path)
 
@@ -84,17 +86,16 @@ class TestSuite(object):
         If this returns false, the nrtest script shall exit before executing
         any tests.
         """
-        p = self.app.tests_path
-        if not os.path.isdir(p):
-            logging.error('Tests directory not found: "%s"' % p)
-            return False
-
         p = self.benchmark_path
         if os.path.exists(p):
             logging.error('Benchmark directory already exists: "%s"' % p)
             return False
         else:
             os.makedirs(p)
+
+        for test in self.tests:
+            if not test.valid_for_execute():
+                return False
 
         return True
 
@@ -109,5 +110,9 @@ class TestSuite(object):
         if not os.path.isdir(p):
             logging.error('Benchmark directory not found: "%s"' % p)
             return False
+
+        for test in self.tests:
+            if not test.valid_for_compare():
+                return False
 
         return True

--- a/nrtest/testsuite.py
+++ b/nrtest/testsuite.py
@@ -9,7 +9,9 @@ from nrtest.test import Test
 
 
 class TestSuite(object):
-    """docstring for TestSuite"""
+    """The TestSuite class stores metadata about the application under test
+    and the tests themselves. It also provides the interface to benchmarks.
+    """
     manifest_fname = 'manifest.json'
 
     def __init__(self, app, tests, benchmark_path):

--- a/nrtest/utility.py
+++ b/nrtest/utility.py
@@ -1,11 +1,22 @@
+# system imports
 import sys
+import re
 
 
 def color(string, c):
-    if not sys.stdout.isatty():
-        return string
+    """Return a colored string, for printing to the terminal.
+    """
     colors = {'r': 31, 'g': 32, 'y': 33, 'b': 34}
-    if c not in colors:
+
+    if not sys.stdout.isatty() or c not in colors:
         return string
     else:
         return '\033[{0}m{1}\033[0m'.format(colors[c], string)
+
+
+def slugify(s):
+    """Returns a filesystem-friendly version of a string.
+    """
+    slug = s.strip().replace(' ', '_')
+    slug = re.sub(r'(?u)[^-\w.]', '', slug)
+    return slug

--- a/scripts/nrtest
+++ b/scripts/nrtest
@@ -10,6 +10,7 @@ from sys import exit
 # nrtest imports
 from nrtest.testsuite import TestSuite
 from nrtest.compare import compare_testsuite
+from nrtest.execute import execute_testsuite
 
 
 def execute(args):
@@ -25,10 +26,10 @@ def execute(args):
     test_files = list(set(test_files))  # remove duplicates
     logging.info('Found %i tests' % len(test_files))
 
-    ts = TestSuite.read_config(args.app, test_files)
+    ts = TestSuite.read_config(args.app, test_files, args.output)
 
     try:
-        success = ts.execute()
+        success = execute_testsuite(ts)
         ts.write_manifest()
     except KeyboardInterrupt:
         logging.warning('Process interrupted by user')
@@ -41,16 +42,16 @@ def execute(args):
 
 
 def compare(args):
-    manifest_new = join(args.new, TestSuite.manifest_fname)
-    manifest_old = join(args.old, TestSuite.manifest_fname)
+    ts_new = TestSuite.read_benchmark(args.new)
+    ts_old = TestSuite.read_benchmark(args.old)
 
-    ts_new = TestSuite.read_manifest(manifest_new)
-    ts_old = TestSuite.read_manifest(manifest_old)
-
-    ts_new.dir = args.new
-    ts_old.dir = args.old
-
-    compatible = compare_testsuite(ts_new, ts_old, args.tolerance)
+    try:
+        compatible = compare_testsuite(ts_new, ts_old, args.tolerance)
+    except KeyboardInterrupt:
+        logging.warning('Process interrupted by user')
+        compatible = False
+    else:
+        logging.info('Finished')
 
     # Non-zero exit code indicates failure
     exit(not compatible)
@@ -66,21 +67,23 @@ if __name__ == '__main__':
                         const=logging.DEBUG, default=logging.INFO)
     subparsers = parser.add_subparsers(title='subcommands')
 
-    execute_parser = subparsers.add_parser('execute', help='execute tests')
-    execute_parser.set_defaults(func=execute)
-    execute_parser.add_argument('app', metavar='app.json',
-                                help='application config card')
-    execute_parser.add_argument('tests', metavar='test.json', nargs='+',
-                                help='test config card or directory containing\
-                                such cards')
+    e_parser = subparsers.add_parser('execute', help='execute tests')
+    e_parser.set_defaults(func=execute)
+    e_parser.add_argument('app', metavar='app.json',
+                          help='application config card')
+    e_parser.add_argument('tests', metavar='test.json', nargs='+',
+                          help='test config card or directory containing\
+                          such cards')
+    e_parser.add_argument('-o', '--output', default='benchmarks/new',
+                          help='Path to benchmark directory')
 
-    compare_parser = subparsers.add_parser('compare', help='compare results')
-    compare_parser.set_defaults(func=compare)
-    compare_parser.add_argument('new', metavar='new_benchmark')
-    compare_parser.add_argument('old', metavar='old_benchmark')
-    compare_parser.add_argument('-t', '--tolerance', default=0.01,
-                                help='Relative precision at which results \
-                                considered compatible')
+    c_parser = subparsers.add_parser('compare', help='compare results')
+    c_parser.set_defaults(func=compare)
+    c_parser.add_argument('new', metavar='new_benchmark')
+    c_parser.add_argument('old', metavar='old_benchmark')
+    c_parser.add_argument('-t', '--tolerance', default=0.01,
+                          help='Relative precision at which results \
+                          considered compatible')
 
     args = parser.parse_args()
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -13,7 +13,7 @@ test_comparison = {
     'name': 'test',
     'version': 1.0,
     'description': None,
-    'dir': 'test_01',
+    'subdir': 'test_01',
     'output_files': ['output.txt'],
     'out_log': 'stdout.log',
     'err_log': 'stderr.log',
@@ -27,7 +27,6 @@ app_execution = {
     'name': 'app',
     'version': 1.0,
     'exe': 'cat',
-    'tests_path': '/path/to/tests',
 }
 
 app_comparison = {

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -28,7 +28,6 @@ app_execution = {
     'version': 1.0,
     'exe': 'cat',
     'tests_path': '/path/to/tests',
-    'benchmark_path': '/path/to/benchmarks',
 }
 
 app_comparison = {


### PR DESCRIPTION
The `benchmark_path` field is moved from Application to TestSuite, and is now determined from a command line option rather than read from the Application config file. The `tests_path` field is moved from Application to Test (renamed `input_dir`), and is now determined from the path where the test config file is found, rather than read from the Application config card. Closes #2 