### PR TITLE
Ability to write benchmark comparison results to file

### DIFF
--- a/nrtest/__init__.py
+++ b/nrtest/__init__.py
@@ -3,6 +3,7 @@
 # system imports
 import os.path
 import logging
+from functools import total_ordering
 
 # third-party imports
 import six
@@ -11,6 +12,7 @@ __author__ = 'David Hall'
 __version__ = '0.2.2'
 
 
+@total_ordering
 class Metadata(dict):
     """Metadata can be accessed using both dictionary and attribute syntax.
     Provides basic validation of input fields, with different requirements for
@@ -52,6 +54,12 @@ class Metadata(dict):
         for k, v in allowed.items():
             if k not in data:
                 data[k] = v
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __lt__(self, other):
+        return self.name < other.name
 
 
 class Application(Metadata):

--- a/nrtest/compare.py
+++ b/nrtest/compare.py
@@ -38,6 +38,10 @@ def compare_testsuite(ts_sut, ts_ref, rtol, atol, outfile):
     receipt = {
         'Application_UnderTest': ts_sut.app.skim(),
         'Application_Reference': ts_ref.app.skim(),
+        'CompareTolerance': {
+            'relative': rtol,
+            'absolute': atol,
+        },
         'Tests': [],
     }
 

--- a/nrtest/compare.py
+++ b/nrtest/compare.py
@@ -2,6 +2,7 @@
 
 # system imports
 import os
+import json
 import logging
 
 # third-party imports
@@ -16,7 +17,7 @@ class CompareException(Exception):
     pass
 
 
-def compare_testsuite(ts_sut, ts_ref, rtol, atol):
+def compare_testsuite(ts_sut, ts_ref, rtol, atol, outfile):
     """Compare the results of a testsuite against a benchmark.
 
     Args:
@@ -34,14 +35,28 @@ def compare_testsuite(ts_sut, ts_ref, rtol, atol):
         logging.warning('SUT and benchmark contain different tests')
         logging.warning('Comparing %i common tests' % len(common_test_names))
 
+    receipt = {
+        'Application_UnderTest': ts_sut.app.skim(),
+        'Application_Reference': ts_ref.app.skim(),
+        'Tests': [],
+    }
+
     # compare all tests and return False if any are incompatible
     compatible = True
     for name in sorted(common_test_names):
         test_sut = tests_sut[name]
         test_ref = tests_ref[name]
 
-        if not compare_test(test_sut, test_ref, rtol, atol):
+        comparison = compare_test(test_sut, test_ref, rtol, atol)
+        receipt['Tests'].append(comparison)
+
+        if not comparison['passed']:
             compatible = False
+
+    if outfile:
+        with open(outfile, 'w') as f:
+            json.dump(receipt, f, sort_keys=True, indent=4,
+                      separators=(',', ': '))
 
     return compatible
 
@@ -57,6 +72,13 @@ def compare_test(test_sut, test_ref, rtol, atol):
     Returns: boolean compatibility
     """
     logger = logging.getLogger(test_sut.name)
+
+    comparison = {
+        'name': test_sut.name,
+        'description': test_sut.description,
+        'passed': None,
+        'error_msg': None,
+    }
 
     compatible = True
     try:
@@ -85,21 +107,22 @@ def compare_test(test_sut, test_ref, rtol, atol):
             try:
                 compatible = compare_file(path_sut, path_ref, rtol, atol)
             except Exception as e:
-                logger.debug(str(e))
-                raise CompareException('Unexpected error occurred during diff')
+                raise CompareException('Exception raised during diff: %s' % e)
 
             if not compatible:
                 raise CompareException('%s: diff failed' % fname)
 
     except CompareException as e:
+        comparison['passed'] = False
+        comparison['error_msg'] = str(e)
         logger.info(color('fail', 'r'))
         logger.info(str(e))
-        compatible = False
 
     else:
+        comparison['passed'] = compatible
         logger.info(color('pass', 'g'))
 
-    return compatible
+    return comparison
 
 
 def validate_testsuite(ts):

--- a/scripts/nrtest
+++ b/scripts/nrtest
@@ -56,7 +56,8 @@ def compare(args):
 
     try:
         logging.info('Found %i tests' % len(ts_new.tests))
-        compatible = compare_testsuite(ts_new, ts_old, args.rtol, args.atol)
+        compatible = compare_testsuite(ts_new, ts_old, args.rtol, args.atol,
+                                       args.output)
     except KeyboardInterrupt:
         logging.warning('Process interrupted by user')
         compatible = False
@@ -91,6 +92,8 @@ if __name__ == '__main__':
     c_parser.set_defaults(func=compare)
     c_parser.add_argument('new', metavar='new_benchmark')
     c_parser.add_argument('old', metavar='old_benchmark')
+    c_parser.add_argument('-o', '--output', default=None,
+                          help='Path to JSON file of comparison results.')
     c_parser.add_argument('--rtol', type=float, default=0.01,
                           help='Relative precision at which results \
                           considered compatible')


### PR DESCRIPTION
@michaeltryby I've added the ability to write the results of the benchmark comparison to a JSON file (closes #17). It can be activated at the command line via:

    nrtest compare new/ old/ -o receipt.json

and the file looks like:

```
receipt.json
{
    "Application_Reference": {
        "description": "EPANET2012",
        "name": "EPANET",
        "version": "2.0.12"
    },
    "Application_UnderTest": {
        "description": "EPANET220",
        "name": "EPANET",
        "version": "2.2.0"
    },
    "CompareTolerance": {
        "absolute": 0.0,
        "relative": 0.01
    },
    "Tests": [
        {
            "description": "A simple example of modeling chlorine decay",
            "name": "Example 1",
            "passed": true
            "error_msg": null,
        },
        {
            "description": "Example of modeling a 55-hour fluoride tracer study.",
            "name": "Example 2",
            "passed": false,
            "error_msg": "Unexpected error occurred during diff"
        }
    ]
}
```

Additionally, the behavior when a comparison routine raises an exception has been adjusted. In the past, the exception message was printed to screen, accompanied by a second message `Unexpected error occurred during diff`. Now you will see a message `Exception raised during diff: [exception message]`, which is also written in this new output file. So you can now raise exceptions in your custom comparison routine and see them appear in the receipt.json file, providing the details that you need for your own application. This essentially fixes #11.

The PR also fixes #16.

Please let me know if the file provides sufficient information for your purposes, and I can merge this.