### PR TITLE
Fix failing shutil.rmtree on Windows

### DIFF
--- a/nrtest/execute.py
+++ b/nrtest/execute.py
@@ -4,13 +4,12 @@
 import os
 import logging
 import tempfile
-import shutil
 import json
 import datetime
 
 # project imports
 from .process import source, execute, monitor
-from .utility import color, copy_file_and_path, which
+from .utility import color, copy_file_and_path, rmtree, which
 
 
 class TestFailure(Exception):
@@ -86,7 +85,7 @@ def _execute(test, app):
                 copy_file_and_path(fname, tmpdir, test.output_dir)
 
     finally:
-        shutil.rmtree(tmpdir)
+        rmtree(tmpdir)
 
     if exitcode == -11:
         raise TestFailure('Segmentation fault')

--- a/nrtest/utility.py
+++ b/nrtest/utility.py
@@ -39,6 +39,30 @@ def copy_file_and_path(rel_path, src_dir, dest):
     shutil.copy(os.path.join(src_dir, rel_path), dest)
 
 
+def rmtree(path):
+    """Delete an entire directory tree.
+
+    This is a wrapper around shutil.rmtree, which handles sporadic
+    failures on Windows machines by repeating the attempted deletion
+    with an exponentially increasing timeout (a total timeout of
+    about 1 second).
+    """
+    # constants taken from CPython's test.support.rmtree()
+    # i.e. Windows implementation of test.support._waitfor()
+    timeout = 0.001
+    max_timeout = 1.0
+    while timeout < max_timeout:
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError:
+            time.sleep(timeout)
+            timeout *= 2
+
+    # final attempt, without exception handling
+    shutil.rmtree(path)
+
+
 def which(program, env):
     """Returns absolute path to first occurence of program in the PATH
     environment variable (echoing the bash script 'which').

--- a/nrtest/utility.py
+++ b/nrtest/utility.py
@@ -43,7 +43,7 @@ def rmtree(path):
     """Delete an entire directory tree.
 
     This is a wrapper around shutil.rmtree, which handles sporadic
-    failures on Windows machines by repeating the attempted deletion
+    failures on Windows machines. It repeats the attempted deletion
     with an exponentially increasing timeout (a total timeout of
     about 1 second).
     """

--- a/nrtest/utility.py
+++ b/nrtest/utility.py
@@ -5,6 +5,7 @@ import os
 import sys
 import re
 import shutil
+import time
 
 
 def color(string, c):


### PR DESCRIPTION
On Windows machines, `shutil.rmtree()` is known to exhibit sporadic failures (see [CPython Issue #22022](https://bugs.python.org/issue22022)). The `test.support.rmtree()` function is more robust, by waiting for the Windows file system to relinquish certain connections to files/directories. However, it is recommended not to use this module in published packages.

This PR adds a wrapper around `shutil.rmtree()` which repeats the attempt to delete the directory tree at increasing time intervals. The timeouts used in this wrapper are taken from the `test.support.rmtree()` function (see [here](https://github.com/python/cpython/blob/3f4db4a0bab073b768fae958e93288bd5d24eadd/Lib/test/support/__init__.py#L349-L355)).

Fixes #19